### PR TITLE
Add standard.site links for Atmosphere PDS integration

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,4 @@
 WORDPRESS_API_URL=https://wp.shaunguimond.com/graphql
 WORDPRESS_PREVIEW_SECRET=a-strong-preview-secret-key-change-in-production
+PDS_URL=https://atp.shaunguimond.com
+PDS_DID=did:plc:baxrcdl7wzboo6ntcgkuzypp

--- a/lib/pds.ts
+++ b/lib/pds.ts
@@ -1,0 +1,97 @@
+const PDS_URL = process.env.PDS_URL
+const PDS_DID = process.env.PDS_DID
+
+interface StandardDocument {
+  uri: string
+  value: {
+    path: string
+    [key: string]: unknown
+  }
+}
+
+interface PdsListRecordsResponse {
+  records: StandardDocument[]
+  cursor?: string
+  error?: string
+  message?: string
+}
+
+// Promise that resolves to the cached map of normalized post path to AT URI.
+// Set once and reused for the lifetime of the Node process.
+let standardDocumentPromise: Promise<Map<string, string>> | null = null
+
+// Fetch all site.standard.document records from the PDS.
+async function fetchStandardDocuments(): Promise<StandardDocument[]> {
+  if (!PDS_URL || !PDS_DID) {
+    return []
+  }
+
+  const allRecords: StandardDocument[] = []
+  let cursor: string | undefined
+
+  // Paginate through all records.
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const params = new URLSearchParams({
+      repo: PDS_DID,
+      collection: 'site.standard.document',
+      limit: '100',
+    })
+    if (cursor) params.set('cursor', cursor)
+
+    const res = await fetch(
+      `${PDS_URL}/xrpc/com.atproto.repo.listRecords?${params}`
+    )
+
+    if (!res.ok) {
+      return allRecords
+    }
+
+    const data: PdsListRecordsResponse = await res.json()
+
+    if (data.error) {
+      return allRecords
+    }
+
+    allRecords.push(...data.records)
+
+    if (data.cursor) {
+      cursor = data.cursor
+    } else {
+      break
+    }
+  }
+
+  return allRecords
+}
+
+// Build a map of normalized post path to AT URI.
+async function buildStandardDocumentMap(): Promise<Map<string, string>> {
+  const records = await fetchStandardDocuments()
+  const map = new Map<string, string>()
+
+  for (const record of records) {
+    // Normalize the path: strip leading/trailing slashes.
+    // E.g., "/posts/test-standard-site/" -> "posts/test-standard-site"
+    const normalizedPath = record.value.path
+      .replace(/^\/+/, '')
+      .replace(/\/+$/, '')
+
+    map.set(normalizedPath, record.uri)
+  }
+
+  return map
+}
+
+// Get the standard document AT URI for a given post slug.
+// Fetches from the PDS once and caches the result for subsequent calls.
+// Parallel callers share the same promise, so only one fetch runs.
+export async function getStandardDocumentUri(
+  slug: string
+): Promise<string | null> {
+  if (standardDocumentPromise === null) {
+    standardDocumentPromise = buildStandardDocumentMap()
+  }
+  const cache = await standardDocumentPromise
+  return cache.get(`posts/${slug}`) ?? null
+}

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -10,10 +10,11 @@ import Layout from '../../components/layout'
 import PostTitle from '../../components/post-title'
 import Tags from '../../components/tags'
 import { getAllPostsWithSlug, getPostAndMorePosts } from '../../lib/api'
+import { getStandardDocumentUri } from '../../lib/pds'
 import { CommentSection } from '../../components/Bluesky/bsky-comments'
 
 // Used to generate `/posts/[slug]` posts from the Wordpress backend.
-export default function Post({ post, posts, preview }) {
+export default function Post({ post, posts, preview, standardDocumentUri }) {
   const router = useRouter()
   const morePosts = posts?.edges
 
@@ -36,6 +37,15 @@ export default function Post({ post, posts, preview }) {
                 property="og:image"
                 content={post.featuredImage?.node.sourceUrl}
               />
+              {standardDocumentUri && (
+                <>
+                  <link rel="alternate" href={standardDocumentUri} />
+                  <link
+                    rel="site.standard.document"
+                    href={standardDocumentUri}
+                  />
+                </>
+              )}
             </Head>
             <PostHeader
               title={post.title}
@@ -67,13 +77,18 @@ export const getStaticProps: GetStaticProps = async ({
   preview = false,
   previewData,
 }) => {
-  const data = await getPostAndMorePosts(params?.slug, preview, previewData)
+  const postSlug = typeof params?.slug === 'string' ? params.slug : null
+  const data = await getPostAndMorePosts(postSlug, preview, previewData)
+  const standardDocumentUri = postSlug
+    ? await getStandardDocumentUri(postSlug)
+    : null
 
   return {
     props: {
       preview,
       post: data.post,
       posts: data.posts,
+      standardDocumentUri,
     },
     //  For Incremental Static Regeneration (ISR), set the revalidate option to 10 seconds.
     revalidate: 10,

--- a/public/.well-known/site.standard.publication
+++ b/public/.well-known/site.standard.publication
@@ -1,0 +1,1 @@
+did:plc:baxrcdl7wzboo6ntcgkuzypp


### PR DESCRIPTION
Add `site.standard.document` link tags to blog posts per the [standard.site convention](https://ebey.dev/blog/3mqpcexp5sk2p).

## Changes

- **lib/pds.ts** — Fetches all `site.standard.document` records from the PDS at build time. Uses a promise lock so parallel `getStaticProps` calls share one fetch. Caches for the lifetime of the Node process.
- **pages/posts/[slug].tsx** — Queries the PDS in `getStaticProps` and renders the two required `<link>` tags in `<Head>` when a matching record exists.
- **public/.well-known/site.standard.publication** — Contains the repo DID for Step 4 (publication discovery).
- **.env** — Added `PDS_URL` and `PDS_DID` environment variables.

## Generated output

Each post with a `site.standard.document` record now includes:

```html
<link rel="alternate" href="at://did:plc:baxrcdl7wzboo6ntcgkuzypp/site.standard.document/[rkey]">
<link rel="site.standard.document" href="at://did:plc:baxrcdl7wzboo6ntcgkuzypp/site.standard.document/[rkey]">
```

Posts without a matching record are unaffected.