### PR TITLE
Fix per-post og:image on blog posts

### DIFF
--- a/components/meta.tsx
+++ b/components/meta.tsx
@@ -1,5 +1,5 @@
 import Head from 'next/head'
-import { CMS_NAME, HOME_OG_IMAGE_URL } from '../lib/constants'
+import { CMS_NAME } from '../lib/constants'
 import { useTheme } from 'next-themes';
 
 export default function Meta() {
@@ -77,7 +77,6 @@ export default function Meta() {
         name="description"
         content={`A statically generated blog example using Next.js and ${CMS_NAME}.`}
       />
-      <meta property="og:image" content={HOME_OG_IMAGE_URL} />
     </Head>
   )
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,6 +5,7 @@ import MoreStories from '../components/more-stories'
 import HeroPost from '../components/hero-post'
 import Layout from '../components/layout'
 import { getAllPostsForHome } from '../lib/api'
+import { HOME_OG_IMAGE_URL } from '../lib/constants'
 import BskySectionRecentPosts from '../components/Bluesky/bsky-section-recent-posts'
 
 export default function Index({ allPosts: { edges }, preview }) {
@@ -18,6 +19,7 @@ export default function Index({ allPosts: { edges }, preview }) {
     <Layout preview={preview}>
       <Head>
         <title>{`Next.js Blog with WordPress`}</title>
+        <meta property="og:image" content={HOME_OG_IMAGE_URL} />
       </Head>
       <Container>
         {heroPost && (


### PR DESCRIPTION
The global `Meta` component set a generic `og:image` on every page. Bluesky scraper picked the first tag, which was the generic Vercel OG image instead of the post featured image.

Move `og:image` from `Meta` to index page only. Post pages already set their own `og:image` in `<Head>`.