### PR TITLE
fix: guard against missing optional data in posts and Bluesky components

### DIFF
--- a/components/Bluesky/bsky-comments.tsx
+++ b/components/Bluesky/bsky-comments.tsx
@@ -18,28 +18,34 @@ type Thread = AppBskyFeedDefs.ThreadViewPost;
 
 
 // Function to fetch the thread data
-const fetchThreadData = async (uri, setThread, setError) => {
+const fetchThreadData = async (uri, setThread, setError, signal) => {
   try {
-    const thread = await getPostThread(uri);
+    const thread = await getPostThread(uri, signal);
     setThread(thread);
   } catch (err) {
+    // Ignore aborted requests (e.g. the component unmounted).
+    if (err instanceof DOMException && err.name === 'AbortError') return;
     setError('Error loading comments');
   }
 };
 
 export const CommentSection = ({ uri }) => {
-  if (!uri) return <div />;
-
-  const [, , did, _, rkey] = uri.split("/");
-  const postUrl = `https://bsky.app/profile/${did}/post/${rkey}`;
-
   const [thread, setThread] = useState<Thread | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [visibleCount, setVisibleCount] = useState(3);
 
   useEffect(() => {
-    fetchThreadData(uri, setThread, setError);
+    if (!uri) return;
+    const controller = new AbortController();
+    fetchThreadData(uri, setThread, setError, controller.signal);
+    return () => controller.abort();
   }, [uri]);
+
+  // Hooks must run unconditionally, so this guard comes after them.
+  if (!uri) return <div />;
+
+  const [, , did, _, rkey] = uri.split("/");
+  const postUrl = `https://bsky.app/profile/${did}/post/${rkey}`;
 
   if (error) {
     return <p className="text-center">{error}</p>;
@@ -199,10 +205,8 @@ const Actions = ({ post }: { post: AppBskyFeedDefs.PostView }) => (
   </div>
 );
 
-const getPostThread = async (uri: string) => {
+const getPostThread = async (uri: string, signal?: AbortSignal) => {
   const params = new URLSearchParams({ uri });
-
-  const paramtype = typeof params;
 
   const res = await fetch(
     "https://public.api.bsky.app/xrpc/app.bsky.feed.getPostThread?" +
@@ -213,6 +217,7 @@ const getPostThread = async (uri: string) => {
         "Accept": "application/json",
       },
       cache: "no-store",
+      signal,
     },
   );
 

--- a/components/Bluesky/bsky-section-recent-posts.tsx
+++ b/components/Bluesky/bsky-section-recent-posts.tsx
@@ -121,10 +121,11 @@ const getAuthorFeed = async () => {
 
 // components/ImageEmbed.js
 const ImageEmbed = ({ images }) => {
-    const hasMultiImages = images.length > 1;
+    const safeImages = Array.isArray(images) ? images : [];
+    const hasMultiImages = safeImages.length > 1;
     return (
         <div className={hasMultiImages ? "grid grid-cols-2 gap-2 row-auto mb-5" : "mb-5"}>
-            {images.map((image, index) => (
+            {safeImages.map((image, index) => (
                 <img className="rounded-2xl w-full max-h-600 h-content object-cover" key={index} src={image.thumb} alt={`image-${index}`} />
             ))}
         </div>
@@ -149,6 +150,11 @@ const ExternalView = ({ embed }) => {
 }
 
 const ViewRecord = ({ record }) => {
+    // Some embedded records may not resolve to a full record view.
+    if (!record?.value || !record?.author) return null;
+
+    const embeds = Array.isArray(record?.embeds) ? record.embeds : [];
+    const firstEmbed = embeds[0];
     const renderTimeFromPost = getRenderTimeFromPost(record.value.createdAt)
     // const postLink = `https://bsky.app/profile/${record.author.handle}/post/${record.uri.split("/")[4]}`;
     const handleLink = `https://bsky.app/profile/${record.author.handle}`;
@@ -176,11 +182,11 @@ const ViewRecord = ({ record }) => {
             <div className="py-3 px-5">
                 <p className="text-lg" dangerouslySetInnerHTML={{ __html: formattedContent }}></p>
 
-                {record?.embeds.length !== 0 && record?.embeds[0].$type === "app.bsky.embed.images#view" ?
-                    <ImageEmbed images={record?.embeds[0].images} /> : ""}
+                {firstEmbed?.$type === "app.bsky.embed.images#view" ?
+                    <ImageEmbed images={firstEmbed?.images} /> : ""}
 
-                {record?.embeds.length !== 0 && record?.embeds[0].$type === "app.bsky.embed.external#view" ?
-                    <ExternalView embed={record?.embeds[0]} /> : ""}
+                {firstEmbed?.$type === "app.bsky.embed.external#view" ?
+                    <ExternalView embed={firstEmbed} /> : ""}
 
             </div>
         </div>

--- a/components/avatar.tsx
+++ b/components/avatar.tsx
@@ -1,16 +1,28 @@
 import Image from "next/image"
 
 export default function Avatar({ author }) {
-  const isAuthorHaveFullName = author?.node?.firstName && author?.node?.lastName
-  const name = isAuthorHaveFullName
-    ? `${author.node.firstName} ${author.node.lastName}`
-    : author.node.name || null
+  const node = author?.node
+  const name =
+    node?.firstName && node?.lastName
+      ? `${node.firstName} ${node.lastName}`
+      : node?.name || null
+  const avatarUrl = node?.avatar?.url
+
+  // A post can have no author or avatar — fall back to a placeholder.
+  if (!avatarUrl) {
+    return (
+      <div className="flex items-center">
+        <div className="w-9 h-9 relative mr-4 rounded-full bg-gray-300" />
+        {name && <div className="text-xl font-bold">{name}</div>}
+      </div>
+    )
+  }
 
   return (
     <div className="flex items-center">
       <div className="w-9 h-9 relative mr-4">
         <Image
-          src={author.node.avatar.url}
+          src={avatarUrl}
           className="rounded-full"
           alt={name}
           fill

--- a/components/categories.tsx
+++ b/components/categories.tsx
@@ -1,16 +1,19 @@
 export default function Categories({ categories }) {
+  const edges = categories?.edges
+
+  // A post can have no categories — nothing to render in that case.
+  if (!Array.isArray(edges) || edges.length === 0) {
+    return null
+  }
+
   return (
     <span className="ml-1">
       under
-      {categories.edges.length > 0 ? (
-        categories.edges.map((category, index) => (
-          <span key={index} className="ml-1">
-            {category.node.name}
-          </span>
-        ))
-      ) : (
-        <span className="ml-1">{categories.edges.node.name}</span>
-      )}
+      {edges.map((category, index) => (
+        <span key={index} className="ml-1">
+          {category.node.name}
+        </span>
+      ))}
     </span>
   )
 }

--- a/components/date.tsx
+++ b/components/date.tsx
@@ -2,5 +2,5 @@ import { parseISO, format } from 'date-fns'
 
 export default function Date({ dateString }) {
   const date = parseISO(dateString)
-  return <time dateTime={dateString}>{format(date, 'LLLL	d, yyyy')}</time>
+  return <time dateTime={dateString}>{format(date, 'LLLL d, yyyy')}</time>
 }

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -16,7 +16,10 @@ import { CommentSection } from '../../components/Bluesky/bsky-comments'
 // Used to generate `/posts/[slug]` posts from the Wordpress backend.
 export default function Post({ post, posts, preview, standardDocumentUri }) {
   const router = useRouter()
-  const morePosts = posts?.edges
+  const morePosts = posts?.edges ?? []
+  // A post may not have tags or a linked Bluesky post.
+  const tags = post?.tags?.edges ?? []
+  const blueskyPostUrl = post?.extraPostInfo?.blueskyPostUrl ?? null
 
   if (!router.isFallback && !post?.slug) {
     return <ErrorPage statusCode={404} />
@@ -55,7 +58,7 @@ export default function Post({ post, posts, preview, standardDocumentUri }) {
             />
             <PostBody content={post.content} />
             <footer className="mx-3">
-              {post.tags.edges.length > 0 && <Tags tags={post.tags} />}
+              {tags.length > 0 && <Tags tags={{ edges: tags }} />}
             </footer>
           </article>
 
@@ -64,7 +67,7 @@ export default function Post({ post, posts, preview, standardDocumentUri }) {
 
           <SectionSeparator />
 
-          <CommentSection uri={post.extraPostInfo.blueskyPostUrl} />
+          <CommentSection uri={blueskyPostUrl} />
         </>
       )}
     </Layout>


### PR DESCRIPTION
Fixes several places where the site would crash (white screen / broken page) if the WordPress or Bluesky API returned less data than the code assumed.

## Fixes

- **`components/categories.tsx`** — when a post has **no categories** the old code hit the `else` branch and read `categories.edges.node.name` (a property of the *array*, not a node) → guaranteed `TypeError`. Now returns `null`.
- **`pages/posts/[slug].tsx`** — tolerated missing `post.tags` and `post.extraPostInfo` (a post without a linked Bluesky post used to crash on `post.extraPostInfo.blueskyPostUrl`).
- **`components/avatar.tsx`** — placeholder when the author or avatar URL is missing instead of passing `undefined` to `next/image`.
- **`components/Bluesky/bsky-section-recent-posts.tsx`** — `ViewRecord` now guards `record.value` / `record.author` (embedded records that don't resolve to a full view used to crash the whole feed); `ImageEmbed` guards the image list.
- **`components/Bluesky/bsky-comments.tsx`**
  - The `if (!uri) return` ran **before** the hooks → React hook-order violation if `uri` was absent on mount. Guard moved below the hooks.
  - In-flight thread fetches are now aborted on unmount (stale `setState` on an unmounted component / duplicate requests when the uri changes).
  - Removed an unused variable.
- **`components/date.tsx`** — a literal **tab character** inside the date-fns format string (`'LLLL\td, yyyy'`) produced e.g. "August	14, 2026".

## Verification

`pnpm build` — 36/36 static pages, no type errors.

Branches off `main` (independent of the pnpm/build PR); verified locally with a repaired `node_modules`.