### PR TITLE
fix: only send the WordPress auth token on preview/draft fetches

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -7,10 +7,17 @@ const API_URL = process.env.WORDPRESS_API_URL as string
 const API_TIMEOUT_MS = 15_000
 
 // Function to fetch data from WPGraphQL API
-async function fetchAPI(query = '', { variables }: Record<string, any> = {}) {
+async function fetchAPI(
+  query = '',
+  { variables, useAuth = false }: Record<string, any> = {}
+) {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
 
-  if (process.env.WORDPRESS_AUTH_REFRESH_TOKEN) {
+  // The auth header is only sent for preview/draft fetches. Build-time
+  // fetches of published content must not depend on the JWT: an expired
+  // token makes WPGraphQL fail every query with a generic
+  // "Internal server error", which fails the whole build.
+  if (useAuth && process.env.WORDPRESS_AUTH_REFRESH_TOKEN) {
     headers[
       'Authorization'
     ] = `Bearer ${process.env.WORDPRESS_AUTH_REFRESH_TOKEN}`
@@ -63,6 +70,7 @@ export async function getPreviewPost(id, idType = 'DATABASE_ID') {
     }`,
     {
       variables: { id, idType },
+      useAuth: true,
     }
   )
   return data.post
@@ -115,7 +123,9 @@ export async function getAllPostsForHome(preview) {
         }
       }
     }
-  `)
+  `,
+    { useAuth: !!preview }
+  )
 
   return data?.posts
 }
@@ -213,6 +223,7 @@ export async function getPostAndMorePosts(slug, preview, previewData) {
         id: isDraft ? postPreview.id : slug,
         idType: isDraft ? 'DATABASE_ID' : 'SLUG',
       },
+      useAuth: !!preview,
     }
   )
 
@@ -318,6 +329,7 @@ export async function getPreviewPage(id, idType = 'DATABASE_ID') {
     }`,
     {
       variables: { id, idType },
+      useAuth: true,
     }
   )
   return data.page
@@ -413,6 +425,7 @@ export async function getPageAndMorePages(uri, preview, previewData) {
         pageid: isDraftPage ? pagePreview.id : uri,
         pageidType: isDraftPage ? 'DATABASE_ID' : 'URI',
       },
+      useAuth: !!preview,
     }
   )
 


### PR DESCRIPTION
Based on #17. Follow-up to today's Vercel build failure.

## Problem

`fetchAPI` attached the `Authorization: Bearer <WORDPRESS_AUTH_REFRESH_TOKEN>` header to **every** WPGraphQL request whenever the env var was set — including build-time fetches of published content. Because the token was scoped to Preview in Vercel, **every preview build sent the JWT**. When it was expired, WPGraphQL failed every query with a generic `Internal server error` (not a clean auth error), and the build died in `getStaticProps` for `/[uri]`.

## Fix

Only the preview/draft fetches send the token now:

- `getPreviewPost`, `getPreviewPage` — always (they exist for preview mode)
- `getPostAndMorePosts`, `getAllPostsForHome`, `getPageAndMorePages` — only when `preview: true`

Public content fetches (all normal build + ISR requests) are unauthenticated, so the build can no longer break because of a stale JWT.

## Why this matters going forward

Preview mode needs a **fresh** `WORDPRESS_AUTH_REFRESH_TOKEN` in Vercel whenever you want to preview WordPress drafts on a deployed site (WPGraphQL JWTs are short-lived). Before this change, adding the token back would have re-introduced the build-breaking behavior the moment the token expired. Now it's safe to set it in any environment scope.

## Verification

- `tsc --noEmit` — clean.
- `pnpm build` — 36/36 pages.
- **`WORDPRESS_AUTH_REFRESH_TOKEN=garbage pnpm build` — passes** (this exact scenario failed before the change).