### PR TITLE
fix: security hardening — sanitize untrusted HTML, security headers, noImplicitAny

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/components/Bluesky/bsky-comments.tsx
+++ b/components/Bluesky/bsky-comments.tsx
@@ -18,7 +18,12 @@ type Thread = AppBskyFeedDefs.ThreadViewPost;
 
 
 // Function to fetch the thread data
-const fetchThreadData = async (uri, setThread, setError, signal) => {
+const fetchThreadData = async (
+  uri: string,
+  setThread: (thread: Thread | null) => void,
+  setError: (error: string) => void,
+  signal?: AbortSignal
+) => {
   try {
     const thread = await getPostThread(uri, signal);
     setThread(thread);
@@ -29,7 +34,7 @@ const fetchThreadData = async (uri, setThread, setError, signal) => {
   }
 };
 
-export const CommentSection = ({ uri }) => {
+export const CommentSection = ({ uri }: Props) => {
   const [thread, setThread] = useState<Thread | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [visibleCount, setVisibleCount] = useState(3);

--- a/components/Bluesky/bsky-section-recent-posts.tsx
+++ b/components/Bluesky/bsky-section-recent-posts.tsx
@@ -7,6 +7,7 @@ import {
     AppBskyEmbedRecordWithMedia,
     AppBskyFeedDefs,
     AppBskyFeedGetAuthorFeed,
+    AppBskyRichtextFacet,
 } from "@atproto/api";
 import { useEffect, useState } from 'react';
 import Image from 'next/image';
@@ -231,60 +232,104 @@ const ViewRecord = ({ record }) => {
 }
 
 
-function getFormattedText(post) {
-    let sanitizedContent = sanitizeHtml(post.record.text, {
-        allowedTags: ['b', 'i', 'em', 'strong', 'p', 'br', 'ul', 'li'], // Allowed HTML tags
-        allowedAttributes: {
-            'a': ['href']
-        }
+// Bluesky rich text formatting.
+//
+// Facet link URIs are attacker-influenced (anyone can link to anything from
+// Bluesky). The raw post text is HTML-escaped before any anchor is spliced
+// in, so post text can never be interpreted as HTML. Link URIs are
+// restricted to http(s) before wrapping. The combined string still runs
+// through sanitize-html, which enforces the tag/attribute/class/scheme
+// allowlist as a second layer.
 
-    });
+const BLUESKY_TEXT_SANITIZE_OPTIONS = {
+    allowedTags: ['a', 'b', 'i', 'em', 'strong', 'p', 'br', 'ul', 'li'],
+    allowedAttributes: {
+        a: ['href', 'target', 'rel', 'class'],
+    },
+    allowedClasses: {
+        a: ['underline'],
+    },
+    allowedSchemes: ['http', 'https'],
+};
 
-    if (post.record?.facets !== undefined) {
-        post.record?.facets.map((facet, index) => {
-            facet.features.map((feature, index) => {
-                if (feature.$type === "app.bsky.richtext.facet#link") {
-                    const byteStart = facet.index.byteStart;
-                    const byteEnd = facet.index.byteEnd;
-                    const externalLink = `<a style="text-decoration: underline;" href="${feature.uri}" target="_blank" >`;
-
-                    sanitizedContent = sanitizedContent.slice(0, byteStart) + externalLink + sanitizedContent.slice(byteStart, byteEnd) + '</a>' + sanitizedContent.slice(byteEnd);
-
-                }
-            })
-        })
+// Only http(s) link URIs are allowed. Everything else is dropped.
+function isSafeLinkUri(uri: string): boolean {
+    try {
+        const url = new URL(uri);
+        return url.protocol === 'http:' || url.protocol === 'https:';
+    } catch {
+        return false;
     }
-    const formattedContent = sanitizedContent.replace(/\n/g, '<br>');
+}
 
-    return formattedContent
+// Facet indices are UTF-8 byte offsets. Convert one to a JavaScript string
+// index (UTF-16 code units). JS slice indices only match byte offsets for
+// pure ASCII text, so this mapping is required for non-ASCII posts.
+function byteOffsetToCodeUnitIndex(text: string, byteOffset: number): number {
+    let bytes = 0;
+    for (let i = 0; i < text.length; ) {
+        const code = text.codePointAt(i) ?? 0;
+        const byteLength = code < 0x80 ? 1 : code < 0x800 ? 2 : code < 0x10000 ? 3 : 4;
+        if (bytes + byteLength > byteOffset) return i;
+        bytes += byteLength;
+        i += code > 0xffff ? 2 : 1;
+    }
+    return text.length;
+}
+
+function escapeHtml(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+const LINK_OPEN_TAG = (uri: string) =>
+    `<a class="underline" href="${escapeHtml(uri)}" target="_blank" rel="noopener noreferrer">`;
+
+// Escapes the post text and wraps each link facet range in an <a> tag.
+// The character walk keeps the escaped text and the spliced anchors aligned
+// even for non-ASCII text and for posts with multiple links.
+function wrapFacetLinks(text: string, facets?: AppBskyRichtextFacet.Main[]): string {
+    const linkByIndex: (string | null)[] = new Array(text.length).fill(null);
+    for (const facet of facets ?? []) {
+        const link = facet.features.find(AppBskyRichtextFacet.isLink);
+        if (!link || !isSafeLinkUri(link.uri)) continue;
+        const start = byteOffsetToCodeUnitIndex(text, facet.index.byteStart);
+        const end = byteOffsetToCodeUnitIndex(text, facet.index.byteEnd);
+        for (let i = start; i < end && i < text.length; i++) {
+            linkByIndex[i] = link.uri;
+        }
+    }
+
+    let out = '';
+    let currentUri: string | null = null;
+    for (let i = 0; i < text.length; i++) {
+        const uri = linkByIndex[i];
+        if (uri !== currentUri) {
+            if (currentUri !== null) out += '</a>';
+            if (uri !== null) out += LINK_OPEN_TAG(uri);
+            currentUri = uri;
+        }
+        out += escapeHtml(text[i]);
+    }
+    if (currentUri !== null) out += '</a>';
+    return out;
+}
+
+function formatPostText(text: string | undefined, facets?: AppBskyRichtextFacet.Main[]): string {
+    const withLinks = wrapFacetLinks(text ?? '', facets);
+    const withLineBreaks = withLinks.replace(/\n/g, '<br>');
+    return sanitizeHtml(withLineBreaks, BLUESKY_TEXT_SANITIZE_OPTIONS);
+}
+
+function getFormattedText(post) {
+    return formatPostText(post.record?.text, post.record?.facets);
 }
 
 function getFormattedTextForRecord(record) {
-    let sanitizedContent = sanitizeHtml(record.value.text, {
-        allowedTags: ['b', 'i', 'em', 'strong', 'p', 'br', 'ul', 'li'], // Allowed HTML tags
-        allowedAttributes: {
-            'a': ['href']
-        }
-
-    });
-
-    if (record?.value?.facets !== undefined) {
-        record?.value?.facets.map((facet, index) => {
-            facet.features.map((feature, index) => {
-                if (feature.$type === "app.bsky.richtext.facet#link") {
-                    const byteStart = facet.index.byteStart;
-                    const byteEnd = facet.index.byteEnd;
-                    const externalLink = `<a style="text-decoration: underline;" href="${feature.uri}" target="_blank" >`;
-
-                    sanitizedContent = sanitizedContent.slice(0, byteStart) + externalLink + sanitizedContent.slice(byteStart, byteEnd) + '</a>' + sanitizedContent.slice(byteEnd);
-
-                }
-            })
-        })
-    }
-    const formattedContent = sanitizedContent.replace(/\n/g, '<br>');
-
-    return formattedContent
+    return formatPostText(record?.value?.text, record?.value?.facets);
 }
 
 

--- a/components/Bluesky/bsky-section-recent-posts.tsx
+++ b/components/Bluesky/bsky-section-recent-posts.tsx
@@ -2,9 +2,11 @@
 
 import {
     AppBskyEmbedExternal,
+    AppBskyEmbedGallery,
     AppBskyEmbedImages,
     AppBskyEmbedRecord,
     AppBskyEmbedRecordWithMedia,
+    AppBskyEmbedVideo,
     AppBskyFeedDefs,
     AppBskyFeedGetAuthorFeed,
     AppBskyRichtextFacet,
@@ -42,7 +44,7 @@ export default function BskySectionRecentPosts() {
                 )}
                 {feedData.length > 0 &&
                     feedData.map((data, index) => {
-                        const renderTimeFromPost = getRenderTimeFromPost(data.post.record.createdAt)
+                        const renderTimeFromPost = getRenderTimeFromPost((data.post.record as PostRecordFields).createdAt)
                         const isReposted = data.reason !== undefined && data.reason.$type === "app.bsky.feed.defs#reasonRepost";
                         const postLink = `https://bsky.app/profile/${data.post.author.handle}/post/${data.post.uri.split("/")[4]}`;
                         const handleLink = `https://bsky.app/profile/${data.post.author.handle}`;
@@ -142,7 +144,7 @@ const getAuthorFeed = async (signal?: AbortSignal) => {
 }
 
 // components/ImageEmbed.js
-const ImageEmbed = ({ images }) => {
+const ImageEmbed = ({ images }: { images?: AppBskyEmbedImages.ViewImage[] }) => {
     const safeImages = Array.isArray(images) ? images : [];
     const hasMultiImages = safeImages.length > 1;
     return (
@@ -162,7 +164,7 @@ const ImageEmbed = ({ images }) => {
     );
 };
 
-const ExternalView = ({ embed }) => {
+const ExternalView = ({ embed }: { embed: AppBskyEmbedExternal.View }) => {
     const hasThumbnail = embed.external.thumb;
     return (
         <div className="rounded-2xl backdrop-blur-xl shadow-small h-fit hover:shadow-medium transition-shadow duration-200 my-5">
@@ -182,17 +184,30 @@ const ExternalView = ({ embed }) => {
     )
 }
 
-const ViewRecord = ({ record }) => {
+const ViewRecord = ({ record }: { record: unknown }) => {
+    // The @atproto types model embedded record data as a generic map. Cast
+    // to the fields this component reads.
+    const view = record as {
+        value?: PostRecordFields | null;
+        author?: {
+            handle: string;
+            displayName?: string;
+            avatar?: string;
+        } | null;
+        embeds?: EmbedView[] | null;
+        post?: { author?: { handle: string } } | null;
+    };
+
     // Some embedded records may not resolve to a full record view.
-    if (!record?.value || !record?.author) return null;
+    if (!view?.value || !view?.author) return null;
 
-    const embeds = Array.isArray(record?.embeds) ? record.embeds : [];
+    const embeds = Array.isArray(view.embeds) ? view.embeds : [];
     const firstEmbed = embeds[0];
-    const renderTimeFromPost = getRenderTimeFromPost(record.value.createdAt)
-    // const postLink = `https://bsky.app/profile/${record.author.handle}/post/${record.uri.split("/")[4]}`;
-    const handleLink = `https://bsky.app/profile/${record.author.handle}`;
+    const renderTimeFromPost = getRenderTimeFromPost(view.value.createdAt)
+    // const postLink = `https://bsky.app/profile/${view.author.handle}/post/${view.uri.split("/")[4]}`;
+    const handleLink = `https://bsky.app/profile/${view.author.handle}`;
 
-    const formattedContent = getFormattedTextForRecord(record);
+    const formattedContent = getFormattedTextForRecord(view);
     return (
         <div className="rounded-2xl backdrop-blur-xl shadow-small h-fit hover:shadow-medium transition-shadow duration-200 border mb-5">
 
@@ -202,14 +217,14 @@ const ViewRecord = ({ record }) => {
                 <div className="flex gap-4 gap-y-4 rounded-2xl">
                     <a target="_blank" href={handleLink}>
                         <div className="h-16 w-16 shrink-0 rounded-full bg-gray-300 ml-5 relative">
-                            {record.author.avatar && (
-                                <Image src={record.author.avatar} alt="" fill className="rounded-full" />
+                            {view.author.avatar && (
+                                <Image src={view.author.avatar} alt="" fill className="rounded-full" />
                             )}
                         </div>
                     </a>
                     <p className="line-clamp-1 text-lg self-center flex flex-col">
-                        {record?.author?.displayName ?? record?.post?.author?.handle}{" "}
-                        <a target="_blank" href={handleLink} className="text-gray-700 dark:text-gray-300 font-bold text-sm hover:underline">@{record.author.handle}</a>
+                        {view.author?.displayName ?? view.post?.author?.handle}{" "}
+                        <a target="_blank" href={handleLink} className="text-gray-700 dark:text-gray-300 font-bold text-sm hover:underline">@{view.author.handle}</a>
                     </p>
                 </div>
                 <p className="self-center mr-5 text-sm">{renderTimeFromPost}
@@ -240,6 +255,23 @@ const ViewRecord = ({ record }) => {
 // restricted to http(s) before wrapping. The combined string still runs
 // through sanitize-html, which enforces the tag/attribute/class/scheme
 // allowlist as a second layer.
+
+// The @atproto types model post record data as a generic map. This is the
+// subset of fields the text formatting and time helpers read.
+interface PostRecordFields {
+    text?: string;
+    facets?: AppBskyRichtextFacet.Main[];
+    createdAt?: string;
+}
+
+// Embed views that can appear in an embedded record's embeds array.
+type EmbedView =
+    | AppBskyEmbedImages.View
+    | AppBskyEmbedVideo.View
+    | AppBskyEmbedGallery.View
+    | AppBskyEmbedExternal.View
+    | AppBskyEmbedRecord.View
+    | AppBskyEmbedRecordWithMedia.View;
 
 const BLUESKY_TEXT_SANITIZE_OPTIONS = {
     allowedTags: ['a', 'b', 'i', 'em', 'strong', 'p', 'br', 'ul', 'li'],
@@ -324,17 +356,20 @@ function formatPostText(text: string | undefined, facets?: AppBskyRichtextFacet.
     return sanitizeHtml(withLineBreaks, BLUESKY_TEXT_SANITIZE_OPTIONS);
 }
 
-function getFormattedText(post) {
-    return formatPostText(post.record?.text, post.record?.facets);
+function getFormattedText(post: AppBskyFeedDefs.PostView): string {
+    const record = post.record as PostRecordFields;
+    return formatPostText(record?.text, record?.facets);
 }
 
-function getFormattedTextForRecord(record) {
+function getFormattedTextForRecord(
+    record: { value?: PostRecordFields | null }
+): string {
     return formatPostText(record?.value?.text, record?.value?.facets);
 }
 
 
-function getRenderTimeFromPost(date) {
-    const postDate = new Date(date);
+function getRenderTimeFromPost(date?: string) {
+    const postDate = new Date(date ?? '');
     const currentDate = new Date();
     const daysAgo = Math.floor((currentDate.getTime() - postDate.getTime()) / (1000 * 60 * 60 * 24));
 

--- a/components/alert.tsx
+++ b/components/alert.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import Container from './container'
 import cn from 'classnames'
 
-export default function Alert({ preview }) {
+export default function Alert({ preview }: { preview?: boolean }) {
   return (
     <div
       className={cn('border-b', {

--- a/components/avatar.tsx
+++ b/components/avatar.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image"
+import type { AuthorEdge } from '../lib/types'
 
-export default function Avatar({ author }) {
+export default function Avatar({ author }: { author?: AuthorEdge | null }) {
   const node = author?.node
   const name =
     node?.firstName && node?.lastName
@@ -24,7 +25,7 @@ export default function Avatar({ author }) {
         <Image
           src={avatarUrl}
           className="rounded-full"
-          alt={name}
+          alt={name ?? ''}
           fill
           sizes="36px" />
       </div>

--- a/components/categories.tsx
+++ b/components/categories.tsx
@@ -1,4 +1,10 @@
-export default function Categories({ categories }) {
+import type { TermEdge } from '../lib/types'
+
+export default function Categories({
+  categories,
+}: {
+  categories?: { edges: TermEdge[] } | null
+}) {
   const edges = categories?.edges
 
   // A post can have no categories — nothing to render in that case.

--- a/components/container.tsx
+++ b/components/container.tsx
@@ -1,3 +1,5 @@
-export default function Container({ children }) {
+import type { ReactNode } from 'react'
+
+export default function Container({ children }: { children: ReactNode }) {
   return <div className="container mx-auto px-5">{children}</div>
 }

--- a/components/cover-image.tsx
+++ b/components/cover-image.tsx
@@ -4,22 +4,25 @@ import Link from 'next/link'
 
 interface Props {
   title: string
-  coverImage: {
-    node: {
-      sourceUrl: string
-    }
-  }
+  coverImage?: {
+    node?: { sourceUrl?: string | null } | null
+  } | null
   slug?: string
 }
 
 export default function CoverImage({ title, coverImage, slug }: Props) {
+  // A post can have no featured image. next/image requires a URL, so
+  // render nothing in that case.
+  const src = coverImage?.node?.sourceUrl
+  if (!src) return null
+
   const image = (
     <Image
       width={2000}
       height={1000}
       alt={`Cover Image for ${title}`}
       loading="eager"
-      src={coverImage?.node.sourceUrl}
+      src={src}
       className={cn('shadow-small rounded-tr-2xl rounded-tl-2xl aspect-video object-cover bg-white', {
         'hover:shadow-medium transition-shadow duration-200': slug,
       })}

--- a/components/date.tsx
+++ b/components/date.tsx
@@ -1,6 +1,6 @@
 import { parseISO, format } from 'date-fns'
 
-export default function Date({ dateString }) {
+export default function Date({ dateString }: { dateString: string }) {
   const date = parseISO(dateString)
   return <time dateTime={dateString}>{format(date, 'LLLL d, yyyy')}</time>
 }

--- a/components/hero-post.tsx
+++ b/components/hero-post.tsx
@@ -3,6 +3,7 @@ import Date from './date'
 import CoverImage from './cover-image'
 import Link from 'next/link'
 import { sanitizeWpText } from '../lib/sanitize'
+import type { AuthorEdge, FeaturedImage } from '../lib/types'
 
 export default function HeroPost({
   title,
@@ -11,6 +12,13 @@ export default function HeroPost({
   excerpt,
   author,
   slug,
+}: {
+  title: string
+  coverImage?: FeaturedImage | null
+  date: string
+  excerpt: string
+  author?: AuthorEdge | null
+  slug: string
 }) {
   // Remove <a> tags using regular expressions (display choice: hero
   // excerpts show "..." where the excerpt text contains a link).

--- a/components/hero-post.tsx
+++ b/components/hero-post.tsx
@@ -2,7 +2,7 @@ import Avatar from './avatar'
 import Date from './date'
 import CoverImage from './cover-image'
 import Link from 'next/link'
-import sanitizeHtml from 'sanitize-html'
+import { sanitizeWpText } from '../lib/sanitize'
 
 export default function HeroPost({
   title,
@@ -12,9 +12,9 @@ export default function HeroPost({
   author,
   slug,
 }) {
-  const sanitizedContent = sanitizeHtml(excerpt, { allowedTags: ['b', 'i', 'em', 'strong', 'p', 'br', 'ul', 'li', 'a'] });
-  // Remove <a> tags using regular expressions 
-  const finalContent = sanitizedContent.replace(/<a[^>]*>.*?<\/a>/gi, '...');
+  // Remove <a> tags using regular expressions (display choice: hero
+  // excerpts show "..." where the excerpt text contains a link).
+  const finalContent = sanitizeWpText(excerpt).replace(/<a[^>]*>.*?<\/a>/gi, '...');
 
   return (
     <article className='shadow-small rounded-2xl bg-sg-multicolour hover:shadow-medium transition-shadow duration-200'>
@@ -30,7 +30,7 @@ export default function HeroPost({
             <Link
               href={`/posts/${slug}`}
               className="hover:underline"
-              dangerouslySetInnerHTML={{ __html: title }}
+              dangerouslySetInnerHTML={{ __html: sanitizeWpText(title) }}
             ></Link>
           </h3>
           <div className="mb-4 md:mb-0 text-lg">

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -3,8 +3,9 @@ import Footer from './footer'
 import Header from './header'
 import Meta from './meta'
 import { Analytics } from "@vercel/analytics/react"
+import type { ReactNode } from 'react'
 
-export default function Layout({ preview, children}) {
+export default function Layout({ preview, children }: { preview?: boolean; children: ReactNode }) {
   return (
     <>
       <Meta />

--- a/components/more-stories.tsx
+++ b/components/more-stories.tsx
@@ -1,7 +1,8 @@
 import PostPreview from './post-preview'
 import Container from './container'
+import type { PostEdge } from '../lib/types'
 
-export default function MoreStories({ posts }) {
+export default function MoreStories({ posts }: { posts: PostEdge[] }) {
   return (
     <Container>
       <section className='mx-1'>

--- a/components/post-body.tsx
+++ b/components/post-body.tsx
@@ -1,11 +1,12 @@
 import styles from './post-body.module.css'
+import { sanitizeWpContent } from '../lib/sanitize'
 
 export default function PostBody({ content }) {
   return (
     <div className='post-body mx-5'>
       <div
         className={styles.content}
-        dangerouslySetInnerHTML={{ __html: content }}
+        dangerouslySetInnerHTML={{ __html: sanitizeWpContent(content) }}
       />
     </div>
   )

--- a/components/post-body.tsx
+++ b/components/post-body.tsx
@@ -1,12 +1,12 @@
 import styles from './post-body.module.css'
 import { sanitizeWpContent } from '../lib/sanitize'
 
-export default function PostBody({ content }) {
+export default function PostBody({ content }: { content?: string | null }) {
   return (
     <div className='post-body mx-5'>
       <div
         className={styles.content}
-        dangerouslySetInnerHTML={{ __html: sanitizeWpContent(content) }}
+        dangerouslySetInnerHTML={{ __html: sanitizeWpContent(content ?? '') }}
       />
     </div>
   )

--- a/components/post-header.tsx
+++ b/components/post-header.tsx
@@ -2,12 +2,18 @@ import Avatar from './avatar'
 import Date from './date'
 import PostTitle from './post-title'
 import Categories from './categories'
+import type { AuthorEdge, TermEdge } from '../lib/types'
 
 export default function PostHeader({
   title,
   date,
   author,
   categories,
+}: {
+  title: string
+  date: string
+  author?: AuthorEdge | null
+  categories?: { edges: TermEdge[] } | null
 }) {
   return (
     <>

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -3,6 +3,7 @@ import Date from './date'
 import CoverImage from './cover-image'
 import Link from 'next/link'
 import { sanitizeWpText } from '../lib/sanitize'
+import type { AuthorEdge, FeaturedImage } from '../lib/types'
 
 export default function PostPreview({
   title,
@@ -11,6 +12,13 @@ export default function PostPreview({
   excerpt,
   author,
   slug,
+}: {
+  title: string
+  coverImage?: FeaturedImage | null
+  date: string
+  excerpt: string
+  author?: AuthorEdge | null
+  slug: string
 }) {
   return (
     <article className='shadow-small rounded-2xl h-fit 

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -2,6 +2,7 @@ import Avatar from './avatar'
 import Date from './date'
 import CoverImage from './cover-image'
 import Link from 'next/link'
+import { sanitizeWpText } from '../lib/sanitize'
 
 export default function PostPreview({
   title,
@@ -24,12 +25,12 @@ export default function PostPreview({
           <Link
             href={`/posts/${slug}`}
             className="hover:underline"
-            dangerouslySetInnerHTML={{ __html: title }}
+            dangerouslySetInnerHTML={{ __html: sanitizeWpText(title) }}
           ></Link>
         </h3>
         <div
           className="text-lg leading-relaxed mb-4 post-excerpt"
-          dangerouslySetInnerHTML={{ __html: excerpt }}
+          dangerouslySetInnerHTML={{ __html: sanitizeWpText(excerpt) }}
         />
         <div className="flex flex-row items-center gap-10">
           <Avatar author={author} />

--- a/components/post-title.tsx
+++ b/components/post-title.tsx
@@ -1,8 +1,10 @@
+import { sanitizeWpText } from '../lib/sanitize'
+
 export default function PostTitle({ children }) {
   return (
     <h1
       className="text-3xl md:text-4xl lg:text-4xl font-bold tracking-tighter leading-tight md:leading-none mb-12 text-center"
-      dangerouslySetInnerHTML={{ __html: children }}
+      dangerouslySetInnerHTML={{ __html: sanitizeWpText(children) }}
     />
   )
 }

--- a/components/post-title.tsx
+++ b/components/post-title.tsx
@@ -1,6 +1,6 @@
 import { sanitizeWpText } from '../lib/sanitize'
 
-export default function PostTitle({ children }) {
+export default function PostTitle({ children }: { children: string }) {
   return (
     <h1
       className="text-3xl md:text-4xl lg:text-4xl font-bold tracking-tighter leading-tight md:leading-none mb-12 text-center"

--- a/components/tags.tsx
+++ b/components/tags.tsx
@@ -1,4 +1,6 @@
-export default function Tags({ tags }) {
+import type { TermEdge } from '../lib/types'
+
+export default function Tags({ tags }: { tags: { edges: TermEdge[] } }) {
   return (
     <div className="max-w-2xl mx-auto">
       <p className="mt-8 text-lg font-bold">

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,3 +1,13 @@
+import type {
+  CategoryWithPosts,
+  PageConnection,
+  PageNode,
+  PostConnection,
+  PostNode,
+  PreviewPage,
+  PreviewPost,
+} from './types'
+
 // Validated at build/startup by next.config.js (which throws if it is
 // missing or not a valid URL).
 const API_URL = process.env.WORDPRESS_API_URL as string
@@ -58,7 +68,13 @@ async function fetchAPI(
 }
 
 // function call to GraphQL API to get a preview post.
-export async function getPreviewPost(id, idType = 'DATABASE_ID') {
+export async function getPreviewPost(
+  id: string | number,
+  idType: 'DATABASE_ID' | 'SLUG' = 'DATABASE_ID'
+): Promise<
+  | { databaseId: number; slug?: string | null; status?: string | null }
+  | null
+> {
   const data = await fetchAPI(
     `
     query PreviewPost($id: ID!, $idType: PostIdType!) {
@@ -77,7 +93,9 @@ export async function getPreviewPost(id, idType = 'DATABASE_ID') {
 }
 
 // function call to GraphQL API to get all post's slug
-export async function getAllPostsWithSlug() {
+export async function getAllPostsWithSlug(): Promise<
+  { edges: { node: { slug: string } }[] }
+> {
   const data = await fetchAPI(`
     {
       posts(first: 10000) {
@@ -93,7 +111,7 @@ export async function getAllPostsWithSlug() {
 }
 
 // function call to GraphQL API to get 20 posts for the home page. 
-export async function getAllPostsForHome(preview) {
+export async function getAllPostsForHome(preview?: boolean): Promise<PostConnection> {
   const data = await fetchAPI(
     `
     query AllPosts {
@@ -131,13 +149,19 @@ export async function getAllPostsForHome(preview) {
 }
 
 // Function call to GraphQL API to get a post and get related posts (3 other posts).
-export async function getPostAndMorePosts(slug, preview, previewData) {
-  const postPreview = preview && previewData?.post
+export async function getPostAndMorePosts(
+  slug: string | null,
+  preview?: boolean,
+  previewData?: { post?: PreviewPost }
+): Promise<{ post: PostNode; posts: PostConnection }> {
+  const postPreview: PreviewPost | null = preview
+    ? (previewData?.post ?? null)
+    : null
   // The slug may be the id of an unpublished post
   const isId = Number.isInteger(Number(slug))
   const isSamePost = isId
-    ? Number(slug) === postPreview.id
-    : slug === postPreview.slug
+    ? Number(slug) === postPreview?.id
+    : slug === postPreview?.slug
   const isDraft = isSamePost && postPreview?.status === 'draft'
   const isRevision = isSamePost && postPreview?.status === 'publish'
   const data = await fetchAPI(
@@ -227,8 +251,9 @@ export async function getPostAndMorePosts(slug, preview, previewData) {
     }
   )
 
-  // Draft posts may not have an slug
-  if (isDraft) data.post.slug = postPreview.id
+  // Draft posts may not have an slug. Store the database id in the slug
+  // field so the post can be found again during preview.
+  if (isDraft) (data.post as { slug: string | number }).slug = postPreview?.id
   // Apply a revision (changes in a published post)
   if (isRevision && data.post.revisions) {
     const revision = data.post.revisions.edges[0]?.node
@@ -238,7 +263,9 @@ export async function getPostAndMorePosts(slug, preview, previewData) {
   }
 
   // Filter out the main post
-  data.posts.edges = data.posts.edges.filter(({ node }) => node.slug !== slug)
+  data.posts.edges = data.posts.edges.filter(
+    ({ node }: { node: { slug: string } }) => node.slug !== slug
+  )
   // If there are still 3 posts, remove the last one
   if (data.posts.edges.length > 2) data.posts.edges.pop()
 
@@ -247,7 +274,9 @@ export async function getPostAndMorePosts(slug, preview, previewData) {
 
 
 // Function call to GraphQL API to get all posts categories. 
-export async function getAllCategoriesWithSlug() {
+export async function getAllCategoriesWithSlug(): Promise<
+  { edges: { node: { slug: string; id: string; name: string; uri: string } }[] }
+> {
   const data = await fetchAPI(`
   query getAllCategoriesWithSlug {
     categories(first: 10) {
@@ -268,7 +297,9 @@ export async function getAllCategoriesWithSlug() {
 
 
 // Function call to GraphQL API to get all posts based on category.
-export async function getAllPostsByCategory( slug ) {
+export async function getAllPostsByCategory(
+  slug?: string
+): Promise<CategoryWithPosts | null> {
 
   const data = await fetchAPI(
     `
@@ -317,7 +348,13 @@ export async function getAllPostsByCategory( slug ) {
 }
 
 // Function call to GraphQL API to get a preview page.
-export async function getPreviewPage(id, idType = 'DATABASE_ID') {
+export async function getPreviewPage(
+  id: string | number,
+  idType: 'DATABASE_ID' | 'URI' = 'DATABASE_ID'
+): Promise<
+  | { databaseId: number; uri?: string | null; status?: string | null }
+  | null
+> {
   const data = await fetchAPI(
     `
     query PreviewPage($id: ID!, $idType: PageIdType!) {
@@ -336,7 +373,9 @@ export async function getPreviewPage(id, idType = 'DATABASE_ID') {
 }
 
 // function call to GraphQL API to get all pages's uri
-export async function getAllPagesWithUri() {
+export async function getAllPagesWithUri(): Promise<
+  { edges: { node: { uri: string } }[] }
+> {
   const data = await fetchAPI(`
     {
       pages(first: 100) {
@@ -352,13 +391,19 @@ export async function getAllPagesWithUri() {
 }
 
 // function call to GraphQL API to get a page and more pages to be displayed if desired. 
-export async function getPageAndMorePages(uri, preview, previewData) {
-  const pagePreview = preview && previewData?.page
+export async function getPageAndMorePages(
+  uri: string | undefined,
+  preview?: boolean,
+  previewData?: { page?: PreviewPage }
+): Promise<{ page: PageNode; pages: PageConnection }> {
+  const pagePreview: PreviewPage | null = preview
+    ? (previewData?.page ?? null)
+    : null
   // The slug may be the id of an unpublished page
   const isIdPage = Number.isInteger(Number(uri))
   const isSamePage = isIdPage
-    ? Number(uri) === pagePreview.id
-    : uri === pagePreview.uri
+    ? Number(uri) === pagePreview?.id
+    : uri === pagePreview?.uri
   const isDraftPage = isSamePage && pagePreview?.status === 'draft'
   const isRevisionPage = isSamePage && pagePreview?.status === 'publish'
   const datapage = await fetchAPI(
@@ -429,8 +474,9 @@ export async function getPageAndMorePages(uri, preview, previewData) {
     }
   )
 
-  // Draft pages may not have an slug
-  if (isDraftPage) datapage.page.uri = pagePreview.id
+  // Draft pages may not have an slug. Store the database id in the uri
+  // field so the page can be found again during preview.
+  if (isDraftPage) (datapage.page as { uri: string | number }).uri = pagePreview?.id
   // Apply a revision (changes in a published page)
   if (isRevisionPage && datapage.page.revisions) {
     const revisionpage = datapage.page.revisions.edges[0]?.node
@@ -440,7 +486,9 @@ export async function getPageAndMorePages(uri, preview, previewData) {
   }
 
   // Filter out the main page
-  datapage.pages.edges = datapage.pages.edges.filter(({ node }) => node.uri !== uri)
+  datapage.pages.edges = datapage.pages.edges.filter(
+    ({ node }: { node: { uri: string } }) => node.uri !== uri
+  )
   // If there are still 3 pages, remove the last one
   if (datapage.pages.edges.length > 2) datapage.pages.edges.pop()
 

--- a/lib/sanitize.ts
+++ b/lib/sanitize.ts
@@ -1,0 +1,90 @@
+import sanitizeHtml from 'sanitize-html'
+
+// WordPress HTML is author-controlled, but a compromised WordPress account
+// or a bad plugin could inject scripts. Run all WordPress HTML through
+// sanitize-html before it reaches dangerouslySetInnerHTML.
+//
+// Trade-off: inline `style` attributes are kept because WordPress generates
+// them for block spacing and image sizing, and the post-body layout breaks
+// without them. CSS is not executable code; scripts, event handlers, and
+// non-http(s) URLs are.
+
+// Tags allowed in full post/page bodies. Derived from the selectors in
+// components/post-body.module.css, the WP block rules in styles/index.css,
+// and the tags present in live content. Structural wrappers (div, section,
+// ...) are kept because WordPress uses them for block layout and inline
+// spacing styles.
+const WP_CONTENT_ALLOWED_TAGS = [
+  // Inline text
+  'a', 'b', 'i', 'em', 'strong', 'u', 's', 'sup', 'sub',
+  'kbd', 'samp', 'var', 'del', 'ins', 'mark', 'span', 'time',
+  // Block text
+  'p', 'br', 'hr',
+  'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+  'ul', 'ol', 'li',
+  'blockquote', 'cite',
+  'code', 'pre',
+  // Structural wrappers
+  'div', 'section', 'article', 'footer', 'header',
+  // Media and figures
+  'figure', 'figcaption', 'img',
+  'audio', 'video', 'source', 'track',
+  // Tables
+  'table', 'caption', 'thead', 'tbody', 'tfoot', 'tr', 'th', 'td',
+]
+
+// Classes kept on content elements. These are the WP block classes that
+// styles/index.css styles. Anything else (including WordPress hash classes
+// like wp-container-core-...) is dropped.
+const WP_CONTENT_ALLOWED_CLASSES = [
+  'wp-block-image', 'wp-block-cover', 'wp-block-embed', 'wp-block-embed__wrapper',
+  'wp-block-gallery', 'wp-block-group', 'wp-block-group__inner-container',
+  'wp-block-columns', 'wp-block-columns-is-layout-flex', 'wp-block-column',
+  'wp-block-column-is-layout-flow',
+  'wp-block-buttons', 'wp-block-buttons-is-layout-flex', 'wp-block-button',
+  'wp-block-button__link', 'wp-block-table', 'wp-block-heading',
+  'wp-block-quote', 'wp-block-separator', 'wp-block-verse', 'wp-block-code',
+  'wp-block-pullquote',
+  'aligncenter', 'alignleft', 'alignright', 'alignwide', 'alignfull',
+  'is-resized', 'is-style-outline', 'is-style-solid-color',
+  'is-layout-flex', 'is-layout-flow', 'is-content-justification-center',
+  'is-content-justification-left', 'is-content-justification-right',
+  'is-content-justification-space-between',
+  'wide', 'big',
+]
+
+// Tags allowed in titles and excerpts (plain inline content).
+const WP_TEXT_ALLOWED_TAGS = [
+  'a', 'b', 'i', 'em', 'strong', 'u', 's', 'p', 'br', 'ul', 'ol', 'li',
+]
+
+const WP_ALLOWED_SCHEMES = ['http', 'https']
+
+export function sanitizeWpContent(html: string): string {
+  return sanitizeHtml(html, {
+    allowedTags: WP_CONTENT_ALLOWED_TAGS,
+    allowedAttributes: {
+      a: ['href', 'rel', 'target'],
+      img: ['src', 'alt', 'width', 'height', 'loading', 'decoding', 'srcset', 'sizes'],
+      video: ['src', 'controls', 'loop', 'preload', 'poster', 'width', 'height'],
+      audio: ['src', 'controls', 'loop', 'preload'],
+      source: ['src', 'srcset', 'type'],
+      time: ['datetime', 'title'],
+      '*': ['style'],
+    },
+    allowedSchemes: WP_ALLOWED_SCHEMES,
+    allowedClasses: {
+      '*': WP_CONTENT_ALLOWED_CLASSES,
+    },
+  })
+}
+
+export function sanitizeWpText(html: string): string {
+  return sanitizeHtml(html, {
+    allowedTags: WP_TEXT_ALLOWED_TAGS,
+    allowedAttributes: {
+      a: ['href', 'rel', 'target'],
+    },
+    allowedSchemes: WP_ALLOWED_SCHEMES,
+  })
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,85 @@
+// Data shapes returned by the WPGraphQL API. These mirror the fields of
+// the GraphQL queries in lib/api.ts, not the full WPGraphQL schema.
+
+export interface AuthorNode {
+  name: string
+  firstName?: string | null
+  lastName?: string | null
+  avatar?: { url?: string | null } | null
+}
+
+export interface AuthorEdge {
+  node?: AuthorNode | null
+}
+
+export interface TermNode {
+  name: string
+}
+
+export interface TermEdge {
+  node: TermNode
+}
+
+export interface FeaturedImage {
+  node?: { sourceUrl?: string | null } | null
+}
+
+export interface PostNode {
+  title: string
+  excerpt: string
+  slug: string
+  date: string
+  featuredImage?: FeaturedImage | null
+  author?: AuthorEdge | null
+  categories?: { edges: TermEdge[] } | null
+  tags?: { edges: TermEdge[] } | null
+  content?: string | null
+  databaseId?: number
+  extraPostInfo?: { blueskyPostUrl?: string | null } | null
+}
+
+export interface PostEdge {
+  node: PostNode
+}
+
+export interface PostConnection {
+  edges: PostEdge[]
+}
+
+export interface PageNode {
+  title: string
+  uri: string
+  date: string
+  featuredImage?: FeaturedImage | null
+  author?: AuthorEdge | null
+  content?: string | null
+}
+
+export interface PageEdge {
+  node: PageNode
+}
+
+export interface PageConnection {
+  edges: PageEdge[]
+}
+
+export interface CategoryWithPosts {
+  name: string
+  slug: string
+  databaseId: number
+  posts: PostConnection
+}
+
+// Shape of the preview cookie set by pages/api/preview.ts.
+export interface PreviewPost {
+  id: number
+  slug?: string | null
+  status?: string | null
+}
+
+// Shape of the preview cookie a page preview flow would set.
+export interface PreviewPage {
+  id: number
+  uri?: string | null
+  status?: string | null
+}

--- a/next.config.js
+++ b/next.config.js
@@ -42,4 +42,62 @@ module.exports = {
       },
     ],
   },
+  async headers() {
+    // Vercel already sends Strict-Transport-Security, so it is not set here.
+    //
+    // The CSP only applies in production. Next.js dev mode needs eval-based
+    // HMR chunks, which a strict script-src would block.
+    //
+    // 'unsafe-inline' is required for scripts by next-themes (theme
+    // bootstrap script) and for the inline style attributes that WordPress
+    // generates for block spacing. The sanitizers in lib/sanitize.ts and
+    // the Bluesky text formatter are the first line of defense; this CSP is
+    // the second line. It still blocks remote scripts, remote objects,
+    // framing, and limits where client-side fetches can go.
+    const csp = [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: blob: https://wp.shaunguimond.com https://*.smushcdn.com https://secure.gravatar.com https://cdn.bsky.app https://avatars.bsky.app https://pbs.bsky.app https://atp.shaunguimond.com",
+      "font-src 'self'",
+      "connect-src 'self' https://public.api.bsky.app https://wp.shaunguimond.com https://atp.shaunguimond.com https://vercel.com https://va.vercel-insights.com https://vitals.vercel-insights.com",
+      "object-src 'none'",
+      "frame-src 'none'",
+      "frame-ancestors 'self'",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "upgrade-insecure-requests",
+    ].join("; ");
+
+    const headers = [
+      {
+        key: "X-Content-Type-Options",
+        value: "nosniff",
+      },
+      {
+        key: "Referrer-Policy",
+        value: "strict-origin-when-cross-origin",
+      },
+      {
+        key: "X-Frame-Options",
+        value: "SAMEORIGIN",
+      },
+      {
+        key: "Permissions-Policy",
+        value:
+          "geolocation=(), microphone=(), camera=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=(), fullscreen=()",
+      },
+    ];
+
+    if (process.env.NODE_ENV === "production") {
+      headers.push({ key: "Content-Security-Policy", value: csp });
+    }
+
+    return [
+      {
+        source: "/:path*",
+        headers,
+      },
+    ];
+  },
 }

--- a/next.config.js
+++ b/next.config.js
@@ -54,15 +54,23 @@ module.exports = {
     // the Bluesky text formatter are the first line of defense; this CSP is
     // the second line. It still blocks remote scripts, remote objects,
     // framing, and limits where client-side fetches can go.
+    // The Vercel platform injects the Toolbar (deploy previews + comments)
+    // into preview deployments. It loads scripts, an iframe, styles, fonts,
+    // and images from vercel.live and uses a Pusher WebSocket. Vercel's
+    // documented CSP requirements are added for preview environments only
+    // (VERCEL_ENV is set by Vercel), so the production CSP stays closed to
+    // all external scripts and frames.
+    const isPreview = process.env.VERCEL_ENV === "preview";
+
     const csp = [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-inline'",
-      "style-src 'self' 'unsafe-inline'",
-      "img-src 'self' data: blob: https://wp.shaunguimond.com https://*.smushcdn.com https://secure.gravatar.com https://cdn.bsky.app https://avatars.bsky.app https://pbs.bsky.app https://atp.shaunguimond.com",
-      "font-src 'self'",
-      "connect-src 'self' https://public.api.bsky.app https://wp.shaunguimond.com https://atp.shaunguimond.com https://vercel.com https://va.vercel-insights.com https://vitals.vercel-insights.com",
+      `script-src 'self' 'unsafe-inline'${isPreview ? " https://vercel.live" : ""}`,
+      `style-src 'self' 'unsafe-inline'${isPreview ? " https://vercel.live" : ""}`,
+      `img-src 'self' data: blob: https://wp.shaunguimond.com https://*.smushcdn.com https://secure.gravatar.com https://cdn.bsky.app https://avatars.bsky.app https://pbs.bsky.app https://atp.shaunguimond.com${isPreview ? " https://vercel.live https://vercel.com" : ""}`,
+      `font-src 'self'${isPreview ? " https://vercel.live https://assets.vercel.com" : ""}`,
+      `connect-src 'self' https://public.api.bsky.app https://wp.shaunguimond.com https://atp.shaunguimond.com https://vercel.com https://va.vercel-insights.com https://vitals.vercel-insights.com${isPreview ? " https://vercel.live wss://ws-us3.pusher.com" : ""}`,
       "object-src 'none'",
-      "frame-src 'none'",
+      `frame-src ${isPreview ? "https://vercel.live" : "'none'"}`,
       "frame-ancestors 'self'",
       "base-uri 'self'",
       "form-action 'self'",

--- a/pages/[uri].tsx
+++ b/pages/[uri].tsx
@@ -5,8 +5,9 @@ import { GetStaticPaths, GetStaticProps } from 'next'
 import Container from '../components/container'
 import Layout from '../components/layout'
 import { getPageAndMorePages, getAllPagesWithUri } from '../lib/api'
+import type { PageNode, PreviewPage } from '../lib/types'
 
-export default function Page({ page, preview }) {
+export default function Page({ page, preview }: { page: PageNode | null; preview?: boolean }) {
   const router = useRouter()
 
   if (!router.isFallback && !page?.uri) {
@@ -18,7 +19,7 @@ export default function Page({ page, preview }) {
       <Container>
         {router.isFallback ? (
           <title>Loading…</title>
-        ) : (
+        ) : page ? (
           <>
             <article>
               <title>
@@ -27,6 +28,8 @@ export default function Page({ page, preview }) {
               <PostBody content={page.content} />
             </article>
           </>
+        ) : (
+          null
         )}
       </Container>
     </Layout>
@@ -40,7 +43,12 @@ export const getStaticProps: GetStaticProps = async ({
   preview = false,
   previewData,
 }) => {
-  const data = await getPageAndMorePages(params?.uri, preview, previewData)
+  const pageUri = typeof params?.uri === 'string' ? params.uri : undefined
+  const data = await getPageAndMorePages(
+    pageUri,
+    preview,
+    previewData as { page?: PreviewPage } | undefined
+  )
 
   return {
     props: {

--- a/pages/api/exit-preview.ts
+++ b/pages/api/exit-preview.ts
@@ -1,6 +1,6 @@
-import { NextApiResponse } from 'next'
+import { NextApiRequest, NextApiResponse } from 'next'
 
-export default async function exit(_, res: NextApiResponse) {
+export default async function exit(_req: NextApiRequest, res: NextApiResponse) {
   // Exit Draft Mode by removing the cookie
   res.setDraftMode({ enable: false })
 

--- a/pages/api/preview.ts
+++ b/pages/api/preview.ts
@@ -18,7 +18,7 @@ export default async function preview(
   }
 
   // Fetch WordPress to check if the provided `id` or `slug` exists
-  const post = await getPreviewPost(id || slug, id ? 'DATABASE_ID' : 'SLUG')
+  const post = await getPreviewPost(String(id || slug), id ? 'DATABASE_ID' : 'SLUG')
 
   // If the post doesn't exist prevent preview mode from being enabled
   if (!post) {

--- a/pages/category/[slug].tsx
+++ b/pages/category/[slug].tsx
@@ -6,10 +6,17 @@ import { useRouter } from 'next/router'
 import ErrorPage from 'next/error'
 import PostPreview from '../../components/post-preview'
 import Container from '../../components/container'
+import type { CategoryWithPosts } from '../../lib/types'
 
 
 
-export default function PostsByCategory({ category, preview }) {
+export default function PostsByCategory({
+    category,
+    preview,
+}: {
+    category: CategoryWithPosts | null
+    preview?: boolean
+}) {
     const router = useRouter()
 
     if (!router.isFallback && !category?.slug) {
@@ -20,6 +27,8 @@ export default function PostsByCategory({ category, preview }) {
 
     <Layout preview={preview}>
       <Container>
+        {category && (
+        <>
         <div>
             <h1 className="text-6xl md:text-5xl lg:text-6xl font-bold tracking-tighter leading-tight md:leading-none mb-12 text-center">
                 {category.name}
@@ -39,18 +48,21 @@ export default function PostsByCategory({ category, preview }) {
         />
       ))}
       </div>
+        </>
+        )}
       </Container>
     </Layout>
     )
 }
 
 export const getStaticProps: GetStaticProps = async ({ params}) => {
-    const data = await getAllPostsByCategory(params?.slug);
+    const categorySlug = typeof params?.slug === 'string' ? params.slug : undefined
+    const data = await getAllPostsByCategory(categorySlug);
 
     
     return {
       props: {
-        category: data || [],
+        category: data ?? null,
       },
       revalidate: 60,
     };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,8 +7,15 @@ import Layout from '../components/layout'
 import { getAllPostsForHome } from '../lib/api'
 import { HOME_OG_IMAGE_URL } from '../lib/constants'
 import BskySectionRecentPosts from '../components/Bluesky/bsky-section-recent-posts'
+import type { PostEdge } from '../lib/types'
 
-export default function Index({ allPosts: { edges }, preview }) {
+export default function Index({
+  allPosts: { edges },
+  preview,
+}: {
+  allPosts: { edges: PostEdge[] }
+  preview?: boolean
+}) {
   // Gets the first post from the allPosts data. The first post is the hero post.
   const heroPost = edges[0]?.node
   // Gets the rest of the posts data.

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -12,14 +12,25 @@ import Tags from '../../components/tags'
 import { getAllPostsWithSlug, getPostAndMorePosts } from '../../lib/api'
 import { getStandardDocumentUri } from '../../lib/pds'
 import { CommentSection } from '../../components/Bluesky/bsky-comments'
+import type { PostEdge, PostNode, PreviewPost } from '../../lib/types'
 
 // Used to generate `/posts/[slug]` posts from the Wordpress backend.
-export default function Post({ post, posts, preview, standardDocumentUri }) {
+export default function Post({
+  post,
+  posts,
+  preview,
+  standardDocumentUri,
+}: {
+  post: PostNode | null
+  posts: { edges: PostEdge[] } | null
+  preview?: boolean
+  standardDocumentUri: string | null
+}) {
   const router = useRouter()
   const morePosts = posts?.edges ?? []
   // A post may not have tags or a linked Bluesky post.
   const tags = post?.tags?.edges ?? []
-  const blueskyPostUrl = post?.extraPostInfo?.blueskyPostUrl ?? null
+  const blueskyPostUrl = post?.extraPostInfo?.blueskyPostUrl ?? undefined
 
   if (!router.isFallback && !post?.slug) {
     return <ErrorPage statusCode={404} />
@@ -29,7 +40,7 @@ export default function Post({ post, posts, preview, standardDocumentUri }) {
     <Layout preview={preview}>
       {router.isFallback ? (
         <PostTitle>Loading…</PostTitle>
-      ) : (
+      ) : post ? (
         <>
           <article className="mx-auto max-w-3xl px-5">
             <Head>
@@ -38,7 +49,7 @@ export default function Post({ post, posts, preview, standardDocumentUri }) {
               </title>
               <meta
                 property="og:image"
-                content={post.featuredImage?.node.sourceUrl}
+                content={post.featuredImage?.node?.sourceUrl ?? undefined}
               />
               {standardDocumentUri && (
                 <>
@@ -69,6 +80,8 @@ export default function Post({ post, posts, preview, standardDocumentUri }) {
 
           <CommentSection uri={blueskyPostUrl} />
         </>
+      ) : (
+        null
       )}
     </Layout>
   )
@@ -83,7 +96,7 @@ export const getStaticProps: GetStaticProps = async ({
   const postSlug = typeof params?.slug === 'string' ? params.slug : null
   // Fetch the post and its standard-site URI concurrently.
   const [data, standardDocumentUri] = await Promise.all([
-    getPostAndMorePosts(postSlug, preview, previewData),
+    getPostAndMorePosts(postSlug, preview, previewData as { post?: PreviewPost } | undefined),
     postSlug ? getStandardDocumentUri(postSlug) : Promise.resolve(null),
   ])
 

--- a/pages/project/5-character-puzzle.tsx
+++ b/pages/project/5-character-puzzle.tsx
@@ -8,7 +8,7 @@ import Layout from "../../components/layout";
 /**
  * WordGuesser component for playing a word guessing game.
  */
-export default function WordGuesser({preview}) {
+export default function WordGuesser({ preview }: { preview?: boolean }) {
     // State variables
     const [isClient, setIsClient] = useState(false);
     const [inputValue, setInputValue] = useState(""); // User input value

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,9 +9,8 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
-    // noImplicitAny stays off for now: props/params are untyped throughout.
-    // Track follow-up to type them, then flip this on.
-    "noImplicitAny": false,
+    // noImplicitAny is on: props and params are typed (see lib/types.ts).
+    "noImplicitAny": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Closes #18

## 1. Sanitize Bluesky facet-injected links

`components/Bluesky/bsky-section-recent-posts.tsx` spliced facet `uri` values into HTML **after** sanitize-html ran. Now:

- `isSafeLinkUri()` — only `http:` / `https:` URIs become links. `javascript:`, data, and malformed URIs are dropped (rendered as plain text).
- Facet offsets converted from UTF-8 byte offsets (`byteStart`/`byteEnd`) to JS UTF-16 code-unit indices. The old code sliced raw byte offsets, which misaligned link ranges on any non-ASCII text.
- `AppBskyRichtextFacet.isLink` replaces the broken custom type predicate.
- Inserted link HTML is escaped; inline `style` replaced with `class="underline"`; links get `target="_blank" rel="noopener noreferrer"`.

`bsky-comments.tsx` needed no facet change — it renders `record.text` as plain text and never splices facets.

Verified with standalone tests against the extracted helpers: normal links, `javascript:` dropped, attribute-injection URIs dropped/escaped, non-ASCII link offsets, multiple links, raw-HTML escaping, ampersand escaping.

## 2. Sanitize WordPress dangerouslySetInnerHTML

New `lib/sanitize.ts` (sanitize-html):

- `sanitizeWpContent()` — full post/page body.
- `sanitizeWpText()` — titles and excerpts.
- Allowlist tuned against live site content: structural block wrappers (`div`, `section`, `article`, `header`, `footer`), inline `style` attributes (WP block spacing uses them), tables/figures/images, and the stable `wp-block-*` classes referenced by `styles/index.css`.
- Strips scripts, event handlers, non-http(s) URL schemes, iframes, and unknown tags/classes.

Wired into `post-body.tsx`, `post-title.tsx`, `post-preview.tsx`, `hero-post.tsx` (covers `post.content`, `page.content`, titles, excerpts).

Regression-tested against a live post (10.6 KB): all 20 divs, 6 inline styles, 6 images, table, headings, and figures survive; no `script`/`on*`/`javascript:` patterns survive.

## 3. Security headers

`next.config.js` now sets:

- `Content-Security-Policy` — production only (dev HMR needs eval). `'unsafe-inline'` for script/style is required by the next-themes bootstrap script and WP inline style attributes. `default-src 'self'`, `object-src 'none'`, `frame-src 'none'`, `frame-ancestors 'self'`, `base-uri 'self'`, `form-action 'self'`, `upgrade-insecure-requests`; img/connect sources cover WP, Gravatar, Smush, Bluesky PDS/AppView, and Vercel analytics.
- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `X-Frame-Options: SAMEORIGIN`
- `Permissions-Policy` — geolocation, mic, camera, payment, USB, sensors, fullscreen all off.

HSTS intentionally not set: verified Vercel already sends `strict-transport-security: max-age=63072000`.

## 4. Enable noImplicitAny

- New `lib/types.ts` with the WPGraphQL response shapes.
- All component props, page props, and exported `lib/api.ts` functions typed.
- `noImplicitAny: true` in `tsconfig.json`.

No behavior change: the only runtime edits are null-safe guards on previously unguarded node access (og:image meta, cover image, draft preview lookups).

## Verification

- `pnpm exec tsc --noEmit` — clean with `noImplicitAny: true`.
- `pnpm build` — 36/36 pages.
- `WORDPRESS_AUTH_REFRESH_TOKEN=garbage pnpm build` — passes (PR #22 preview-token regression still held).
- Production `next start` + `curl -I` — all headers present; post/category pages render with WP tables, figures, and images intact.