### PR TITLE
fix: ensure every document has a head <title> element

### DIFF
--- a/pages/[uri].tsx
+++ b/pages/[uri].tsx
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/router'
 import ErrorPage from 'next/error'
+import Head from 'next/head'
 import PostBody from '../components/post-body'
 import { GetStaticPaths, GetStaticProps } from 'next'
 import Container from '../components/container'
@@ -16,18 +17,20 @@ export default function Page({ page, preview }: { page: PageNode | null; preview
 
   return (
     <Layout preview={preview}>
+      <Head>
+        <title>
+          {router.isFallback
+            ? 'Loading…'
+            : `${page?.title ?? 'Page not found'} | Shaun Guimond`}
+        </title>
+      </Head>
       <Container>
         {router.isFallback ? (
-          <title>Loading…</title>
+          <p className="my-8 text-center">Loading…</p>
         ) : page ? (
-          <>
-            <article>
-              <title>
-                {`${page.title} | Next.js Blog with WordPress`}
-              </title>
-              <PostBody content={page.content} />
-            </article>
-          </>
+          <article>
+            <PostBody content={page.content} />
+          </article>
         ) : (
           null
         )}

--- a/pages/category/[slug].tsx
+++ b/pages/category/[slug].tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/router'
 import ErrorPage from 'next/error'
 import PostPreview from '../../components/post-preview'
 import Container from '../../components/container'
+import Head from 'next/head'
 import type { CategoryWithPosts } from '../../lib/types'
 
 
@@ -26,6 +27,13 @@ export default function PostsByCategory({
     return(
 
     <Layout preview={preview}>
+      <Head>
+        <title>
+          {router.isFallback
+            ? 'Loading…'
+            : `${category?.name ?? 'Category'} | Shaun Guimond`}
+        </title>
+      </Head>
       <Container>
         {category && (
         <>

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -38,15 +38,21 @@ export default function Post({
 
   return (
     <Layout preview={preview}>
+      <Head>
+        <title>
+          {router.isFallback
+            ? 'Loading…'
+            : post
+              ? `${post.title} | Shaun Guimond`
+              : 'Post not found | Shaun Guimond'}
+        </title>
+      </Head>
       {router.isFallback ? (
         <PostTitle>Loading…</PostTitle>
       ) : post ? (
         <>
           <article className="mx-auto max-w-3xl px-5">
             <Head>
-              <title>
-                {`${post.title} | Shaun Guimond`}
-              </title>
               <meta
                 property="og:image"
                 content={post.featuredImage?.node?.sourceUrl ?? undefined}

--- a/pages/project/5-character-puzzle.tsx
+++ b/pages/project/5-character-puzzle.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from "react";
+import Head from "next/head";
 import { WORDS } from "../../lib/constants";
 import Layout from "../../components/layout";
 
@@ -137,6 +138,9 @@ export default function WordGuesser({ preview }: { preview?: boolean }) {
     // Render the WordGuesser component
     return (
         <Layout preview={preview}>
+        <Head>
+            <title>5 Character Puzzle | Shaun Guimond</title>
+        </Head>
         <article className="flex w-full flex-col items-center justify-center">
             <div className="word-guesser">
                 <h1 className="text-2xl mb-5 text-center font-bold">5 Character Puzzle</h1>


### PR DESCRIPTION
Closes #26

Fixes the axe `document-title` violation ("Documents must have a `<title>` element to aid in navigation").

## Changes

- **`/category/[slug]`** (e.g. `/category/travels`): no title at all — added a `<Head>` with the category name.
- **`/[uri]`** (e.g. `/about-shaun`, `/privacy-policy`): the `<title>` was rendered **inside the body** `<article>` (invalid placement — the document had no title). Moved it into a `<Head>`; the fallback state now shows "Loading…"; the suffix is now the standard `| Shaun Guimond` instead of the stale `| Next.js Blog with WordPress`.
- **`/project/5-character-puzzle`**: no title at all — added a `<Head>` with a title.
- **`/posts/[slug]`** (found during the sweep): the title only rendered in the non-fallback branch, so the fallback (loading) template had no document title. Hoisted the `<title>` to an always-rendered `<Head>`.

## Verification

Checked the head section of **every** built page in `.next/server/pages`:

- 21 posts — `{post title} | Shaun Guimond`
- 7 categories — `{category} | Shaun Guimond`
- `/about-shaun`, `/privacy-policy` — proper titles
- `/` — `Shaun Guimond`
- `/project/5-character-puzzle` — `5 Character Puzzle | Shaun Guimond`
- Fallback templates (`[uri].html`, `posts/[slug].html`) — `Loading…`
- `/404`, `/500` — built-in Next.js titles

`tsc --noEmit` clean; clean `pnpm build` passes.