### PR TITLE
fix: show comments before suggested posts on post pages

### DIFF
--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -80,11 +80,16 @@ export default function Post({
           </article>
 
           <SectionSeparator />
-          {morePosts.length > 0 && <MoreStories posts={morePosts} />}
-
-          <SectionSeparator />
 
           <CommentSection uri={blueskyPostUrl} />
+
+          {morePosts.length > 0 && (
+            <>
+              <SectionSeparator />
+
+              <MoreStories posts={morePosts} />
+            </>
+          )}
         </>
       ) : (
         null


### PR DESCRIPTION
Fixes #28

Flips the order of the sections at the end of each post page:

- Before: post body → suggested posts → comments → footer
- After: post body → comments → suggested posts → footer

The separator before the suggested posts is now only rendered when there
are suggested posts, so posts with no more-stories don't render a stray
separator before the footer.