### PR TITLE
Embed Sifa profile card on About page via iframe

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -59,8 +59,11 @@ module.exports = {
     // and images from vercel.live and uses a Pusher WebSocket. Vercel's
     // documented CSP requirements are added for preview environments only
     // (VERCEL_ENV is set by Vercel), so the production CSP stays closed to
-    // all external scripts and frames.
+    // all external scripts.
     //
+    // The one external frame allowed in production is sifa.id: the About
+    // page shows a Sifa profile card via <iframe src="https://sifa.id/embed/
+    // <handle>">, the same URL Sifa's own embed-builder preview iframes.
     const isPreview = process.env.VERCEL_ENV === "preview";
 
     const csp = [
@@ -71,7 +74,7 @@ module.exports = {
       `font-src 'self'${isPreview ? " https://vercel.live https://assets.vercel.com" : ""}`,
       `connect-src 'self' https://public.api.bsky.app https://wp.shaunguimond.com https://atp.shaunguimond.com https://vercel.com https://va.vercel-insights.com https://vitals.vercel-insights.com${isPreview ? " https://vercel.live wss://ws-us3.pusher.com" : ""}`,
       "object-src 'none'",
-      `frame-src ${isPreview ? "https://vercel.live" : "'none'"}`,
+      `frame-src 'none' https://sifa.id${isPreview ? " https://vercel.live" : ""}`,
       "frame-ancestors 'self'",
       "base-uri 'self'",
       "form-action 'self'",

--- a/pages/about-shaun.tsx
+++ b/pages/about-shaun.tsx
@@ -64,6 +64,23 @@ export default function AboutShaun() {
             Caroline and Shaun at the Bay of Fundy.
           </figcaption>
         </figure>
+
+        <section className="mt-16" aria-label="My profile on Sifa">
+          <h2 className="font-serif text-3xl font-bold tracking-tighter mb-4">
+            Around the web
+          </h2>
+          <p className="text-lg leading-relaxed text-black dark:text-accent-1 mb-8">
+            I post about technology, programming, and life on Bluesky. Follow
+            along, or check out my full profile on Sifa:
+          </p>
+          <iframe
+            src="https://sifa.id/embed/shaunguimond.com"
+            title="Sifa ID profile card for Shaun Guimond"
+            className="w-full rounded-xl"
+            style={{ height: "356px" }}
+            loading="lazy"
+          />
+        </section>
       </div>
     </Layout>
   )


### PR DESCRIPTION
Closes #32

## What

Shows a live Sifa profile card on the About page's "Around the web" section using an `<iframe>` pointing at `https://sifa.id/embed/shaunguimond.com` — the exact URL Sifa's own embed-builder preview iframes (their page ships `noindex, nofollow`, i.e. built for embedding).

This avoids their `embed.js` script entirely, whose shadow-DOM card has two rendering bugs (location shows as `[object Object]`, "open to" pills show raw `id.sifa.defs#...` identifiers).

## Changes

- `pages/about-shaun.tsx` — "Around the web" section with the iframe (356px tall, matching Sifa's own preview; lazy-loaded)
- `next.config.js` — CSP `frame-src` now allows `https://sifa.id` in production (previously `'none'`); also cleaned up a dangling comment line

## Stacked PR

Based on `feat/custom-about-privacy-pages` (#31) since the About page itself lands there. Once #31 merges, this PR's base flips to `main` automatically.

## Tophat checklist

1. Open the preview's About page — the Sifa card should render inside "Around the web" with correct location and colored app badges
2. Check light + dark mode (note: the card follows the visitor's *system* theme, not the site's toggle)
3. Check mobile width

## If it doesn't work

If the iframe loads blank, Sifa's `frame-ancestors` header is blocking cross-origin framing. Fallback: revert to the `embed.js` script approach (client component injecting the script into a mount-scoped container — `next/script` can't be used because the pages router appends it to `document.body`, which put the card below the footer on every page).
