### PR TITLE
fix: override transitive nanoid to 3.3.18 (Dependabot high)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,10 @@
   "packageManager": "pnpm@9.12.1+sha512.e5a7e52a4183a02d5931057f7a0dbff9d5e9ce3161e33fa68ae392125b79282a8a8a470a51dfc8a0ed86221442eb2fb57019b0990ed24fab519bf0e1bc5ccfc4",
   "overrides": {
     "postcss": "$postcss"
+  },
+  "pnpm": {
+    "overrides": {
+      "nanoid": "3.3.18"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  nanoid: 3.3.18
+
 importers:
 
   .:
@@ -781,8 +784,8 @@ packages:
   multiformats@13.4.2:
     resolution: {integrity: sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1453,7 +1456,7 @@ snapshots:
 
   multiformats@13.4.2: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   next-themes@0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
@@ -1495,13 +1498,13 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
Closes #35

## What

Dependabot high alert: transitive `nanoid 3.3.17` (infinite-loop DoS in `customAlphabet`/`customRandom` with size 0) enters via six parents: next, postcss, autoprefixer, @tailwindcss/postcss, @vercel/analytics, sanitize-html.

## Fix

- `package.json`: added `pnpm.overrides` pinning `nanoid` to `3.3.18` (exact — a `>=` range could resolve to future breaking majors)
- `pnpm-lock.yaml`: regenerated; all six parents now resolve nanoid 3.3.18, and the override is recorded in the lockfile header

The lockfile diff is surgical: only nanoid version lines + the `overrides:` header.

## Side finding (not changed here)

The existing top-level `"overrides": { "postcss": "$postcss" }` entry is npm syntax — pnpm 9 ignores it (overrides must live under `pnpm.overrides`). Evidence: the lockfile still contains two postcss versions (8.5.23 and 8.5.26). Happy to follow up with a small PR that moves it to `pnpm.overrides` so it actually dedupes postcss.
